### PR TITLE
added u modifier to $regexEnd

### DIFF
--- a/src/JCrowe/BadWordFilter/BadWordFilter.php
+++ b/src/JCrowe/BadWordFilter/BadWordFilter.php
@@ -52,7 +52,7 @@ class BadWordFilter
      *
      * @var string
      */
-    private $regexEnd = '([-!$%^&*()_+|~=`{}\[\]:\";\'?,.\/])?\b/i';
+    private $regexEnd = '([-!$%^&*()_+|~=`{}\[\]:\";\'?,.\/])?\b/iu';
 
 
     /**


### PR DESCRIPTION
getDirtyWordsFromString methot returns wrong values if string contains some turkish characters like "ç".

u (PCRE_UTF8)
This modifier turns on additional functionality of PCRE that is incompatible with Perl. Pattern and subject strings are treated as UTF-8. An invalid subject will cause the preg_* function to match nothing; an invalid pattern will trigger an error of level E_WARNING. Five and six octet UTF-8 sequences are regarded as invalid since PHP 5.3.4 (resp. PCRE 7.3 2007-08-28); formerly those have been regarded as valid UTF-8.